### PR TITLE
Add .cjs extension to calls to force CommonJS mode in Node v12+

### DIFF
--- a/install.js
+++ b/install.js
@@ -49,12 +49,12 @@ export ZEIT_GITHOOKS_RUNNING=1
 
 arg0="$(basename \${0})"
 
-if [[ "\${arg0}" == "_do_hook" ]]; then
+if [[ "\${arg0}" == "_do_hook.cjs" ]]; then
 	echo "You probably didn't mean to call this directly." >&2
 	exit 2
 fi
 
-"${nodeBin}" "$(dirname "\${0}")/_detect_package_hooks" "\${arg0}" | while IFS='' read -r hook || [[ -n "\${hook}" ]]; do
+"${nodeBin}" "$(dirname "\${0}")/_detect_package_hooks.cjs" "\${arg0}" | while IFS='' read -r hook || [[ -n "\${hook}" ]]; do
 	echo "△  run hook: \${arg0} -> \${hook}" >&2
 	if [[ $# -gt 0 ]]; then
 		"${nodeBin}" "${packageManagerBin}" run "\${hook}" -- "$@"
@@ -107,8 +107,8 @@ function writeExecutable(path, ...args) {
 }
 
 console.error(`△  @zeit/git-hooks: installing base hook to ${hooksDir}`);
-writeExecutable(path.join(hooksDir, '_do_hook'), hook, 'utf-8');
-writeExecutable(path.join(hooksDir, '_detect_package_hooks'), hookDetector, 'utf-8');
+writeExecutable(path.join(hooksDir, '_do_hook.cjs'), hook, 'utf-8');
+writeExecutable(path.join(hooksDir, '_detect_package_hooks.cjs'), hookDetector, 'utf-8');
 
 // Populate each of the hooks
 function installHook(name) {
@@ -119,7 +119,7 @@ function installHook(name) {
 		return;
 	}
 
-	fs.symlinkSync('./_do_hook', hookPath);
+	fs.symlinkSync('./_do_hook.cjs', hookPath);
 }
 
 [

--- a/uninstall.js
+++ b/uninstall.js
@@ -34,7 +34,7 @@ function uninstallHook(name) {
 		return;
 	}
 
-	const isOneOfOurs = fs.lstatSync(hookPath).isSymbolicLink() && fs.readlinkSync(hookPath) === './_do_hook';
+	const isOneOfOurs = fs.lstatSync(hookPath).isSymbolicLink() && fs.readlinkSync(hookPath) === './_do_hook.cjs';
 
 	if (!isOneOfOurs) {
 		console.error(`△  @zeit/git-hooks: hook '${name}' appears to be a user hook; skipping: ${hookPath}`);
@@ -73,7 +73,7 @@ function removeIfExists(path) {
 	}
 }
 
-removeIfExists(path.join(hooksDir, '_do_hook'));
-removeIfExists(path.join(hooksDir, '_detect_package_hooks'));
+removeIfExists(path.join(hooksDir, '_do_hook.cjs'));
+removeIfExists(path.join(hooksDir, '_detect_package_hooks.cjs'));
 
 console.error('△  @zeit/git-hooks: hooks uninstalled successfully');


### PR DESCRIPTION
Fixes #6.

@Qix- You were correct! Adding `.cjs` to all calls and writes of `_do_hook` and `_detect_package_hooks` didn't bother Node v10 (which just runs them as CommonJS as always), and it successfully makes both Node v12 and Node v14 aware.

I was just testing it out by uninstalling and reinstalling then triggering the commit hook in the repo I discovered this in, so might benefit from another person poking on it.